### PR TITLE
Retheme to "Alien Dessert Rift" and add lifelike alien agents

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alien Rift 3D</title>
+  <title>Alien Dessert Rift 3D</title>
   <style>
     :root {
       color-scheme: dark;
@@ -121,7 +121,7 @@
 </head>
 <body>
   <div class="shell">
-    <h1>ALIEN RIFT 3D</h1>
+    <h1>ALIEN DESSERT RIFT 3D</h1>
     <canvas id="game" width="960" height="540" aria-label="Alien Rift game viewport"></canvas>
 
     <div class="hud">
@@ -134,7 +134,7 @@
     <div id="overlay" class="overlay">
       <div class="panel">
         <h2 id="overlayTitle">Defend the Rift</h2>
-        <p id="overlayText">WASD / Arrow keys to move, mouse to look, Space to blast aliens. Survive as long as possible with support from your local open-source tactical AI.</p>
+        <p id="overlayText">WASD / Arrow keys to move, mouse to look, Space to blast aliens. Survive the glowing dessert dunes while super-realistic alien AI agents hunt with lifelike movement.</p>
         <button id="startBtn">START MISSION</button>
       </div>
     </div>
@@ -184,7 +184,8 @@
         x: (Math.random() - 0.5) * 200,
         y: 20 + Math.random() * 110,
         z: 20 + Math.random() * 220,
-        r: Math.random() * 1.8 + 0.3
+        r: Math.random() * 1.8 + 0.3,
+        tint: Math.random() < 0.4 ? '255,190,140' : '255,236,206'
       });
     }
 
@@ -221,17 +222,32 @@
       const angle = Math.random() * Math.PI * 2;
       const radius = 24 + Math.random() * world.maxSpawnRadius;
       const size = 0.8 + Math.random() * 1.4;
+      const heading = Math.random() * Math.PI * 2;
       world.aliens.push({
         x: world.player.x + Math.cos(angle) * radius,
         y: 1.2 + Math.random() * 0.8,
         z: world.player.z + Math.sin(angle) * radius,
         size,
         speed: (1.3 + Math.random() * 0.9 + world.wave * 0.08) * (0.85 + world.ai.aggression * 0.25),
+        topSpeed: 6.2 + Math.random() * 3,
+        vx: Math.cos(heading) * 0.5,
+        vz: Math.sin(heading) * 0.5,
+        heading,
+        turnRate: 1.5 + Math.random() * 1.2,
         hp: 1 + Math.floor(world.wave / 3),
         bob: Math.random() * Math.PI * 2,
         strafePhase: Math.random() * Math.PI * 2,
-        strafeStrength: 0.45 + Math.random() * 0.7
+        strafeStrength: 0.45 + Math.random() * 0.7,
+        gaitPhase: Math.random() * Math.PI * 2,
+        armSwing: 0,
+        legSwing: 0
       });
+    }
+
+    function wrapAngle(a) {
+      while (a > Math.PI) a -= Math.PI * 2;
+      while (a < -Math.PI) a += Math.PI * 2;
+      return a;
     }
 
     function updateOpenSourceAi(dt) {
@@ -306,14 +322,46 @@
         const dist = Math.hypot(dx, dz) || 0.001;
         alien.bob += dt * 4;
         alien.strafePhase += dt * (1.8 + world.ai.skill * 2.3);
+        alien.gaitPhase += dt * (4.5 + alien.speed * 0.32);
         alien.y = 1.2 + Math.sin(alien.bob) * 0.25;
         const nx = dx / dist;
         const nz = dz / dist;
         const sideX = -nz;
         const sideZ = nx;
         const strafe = Math.sin(alien.strafePhase) * alien.strafeStrength * world.ai.skill;
-        alien.x += (nx + sideX * strafe) * alien.speed * dt;
-        alien.z += (nz + sideZ * strafe) * alien.speed * dt;
+        const desiredX = nx + sideX * strafe;
+        const desiredZ = nz + sideZ * strafe;
+        const targetHeading = Math.atan2(desiredZ, desiredX);
+        const headingDelta = wrapAngle(targetHeading - alien.heading);
+        alien.heading += Math.max(-alien.turnRate * dt, Math.min(alien.turnRate * dt, headingDelta));
+
+        let avoidX = 0;
+        let avoidZ = 0;
+        for (const other of world.aliens) {
+          if (other === alien) continue;
+          const ox = alien.x - other.x;
+          const oz = alien.z - other.z;
+          const d = Math.hypot(ox, oz) || 0.001;
+          if (d < 2.3) {
+            const push = (2.3 - d) / 2.3;
+            avoidX += (ox / d) * push;
+            avoidZ += (oz / d) * push;
+          }
+        }
+
+        const accel = alien.speed * (0.9 + world.ai.skill * 0.8);
+        alien.vx += (Math.cos(alien.heading) * accel + avoidX * 5 - alien.vx * 1.9) * dt;
+        alien.vz += (Math.sin(alien.heading) * accel + avoidZ * 5 - alien.vz * 1.9) * dt;
+        const vel = Math.hypot(alien.vx, alien.vz) || 0.001;
+        if (vel > alien.topSpeed) {
+          alien.vx = (alien.vx / vel) * alien.topSpeed;
+          alien.vz = (alien.vz / vel) * alien.topSpeed;
+        }
+
+        alien.x += alien.vx * dt;
+        alien.z += alien.vz * dt;
+        alien.legSwing = Math.sin(alien.gaitPhase) * 0.75;
+        alien.armSwing = Math.sin(alien.gaitPhase + Math.PI / 2) * 0.55;
 
         if (dist < 1.5) {
           world.player.health -= dt * (6 + world.wave * 0.4);
@@ -373,28 +421,25 @@
 
     function draw() {
       const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
-      grad.addColorStop(0, '#020714');
-      grad.addColorStop(0.7, '#0d1329');
-      grad.addColorStop(1, '#05070f');
+      grad.addColorStop(0, '#3c1f17');
+      grad.addColorStop(0.62, '#9a5d2c');
+      grad.addColorStop(1, '#25120e');
       ctx.fillStyle = grad;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      drawDesertMist();
 
       for (const s of world.stars) {
         const p = projectPoint(s.x, s.y, world.player.z + s.z);
         if (!p) continue;
         const alpha = Math.min(1, 170 / p.depth);
-        ctx.fillStyle = `rgba(200,240,255,${alpha})`;
+        ctx.fillStyle = `rgba(${s.tint},${alpha})`;
         ctx.beginPath();
         ctx.arc(p.x, p.y, s.r * (p.scale * 0.007), 0, Math.PI * 2);
         ctx.fill();
       }
 
-      ctx.strokeStyle = 'rgba(108,255,239,0.13)';
-      ctx.lineWidth = 1;
-      for (let i = -18; i <= 18; i++) {
-        drawGroundLine(i, -60, i, 60);
-        drawGroundLine(-60, i, 60, i);
-      }
+      drawDessertDunes();
 
       const renderables = [];
 
@@ -414,18 +459,7 @@
 
       for (const r of renderables) {
         if (r.type === 'alien') {
-          const sizePx = r.alien.size * r.p.scale;
-          const glow = Math.min(0.9, 2 / r.p.depth);
-          ctx.fillStyle = `rgba(118,255,163,${0.4 + glow * 0.45})`;
-          ctx.beginPath();
-          ctx.ellipse(r.p.x, r.p.y - sizePx * 0.25, sizePx * 0.5, sizePx * 0.68, 0, 0, Math.PI * 2);
-          ctx.fill();
-
-          ctx.fillStyle = 'rgba(40,255,120,0.7)';
-          ctx.beginPath();
-          ctx.arc(r.p.x - sizePx * 0.15, r.p.y - sizePx * 0.3, Math.max(2, sizePx * 0.07), 0, Math.PI * 2);
-          ctx.arc(r.p.x + sizePx * 0.15, r.p.y - sizePx * 0.3, Math.max(2, sizePx * 0.07), 0, Math.PI * 2);
-          ctx.fill();
+          drawRealisticAlienAgent(r);
         } else {
           const size = Math.max(2, r.p.scale * 0.08);
           ctx.fillStyle = 'rgba(170,240,255,0.95)';
@@ -436,6 +470,85 @@
       }
 
       drawCrosshair();
+    }
+
+    function drawDesertMist() {
+      const y = canvas.height * 0.38;
+      const mist = ctx.createLinearGradient(0, y, 0, canvas.height);
+      mist.addColorStop(0, 'rgba(255,173,99,0)');
+      mist.addColorStop(1, 'rgba(255,170,92,0.21)');
+      ctx.fillStyle = mist;
+      ctx.fillRect(0, y, canvas.width, canvas.height - y);
+    }
+
+    function drawDessertDunes() {
+      ctx.strokeStyle = 'rgba(255,208,150,0.18)';
+      ctx.lineWidth = 1;
+      for (let i = -18; i <= 18; i++) {
+        drawGroundLine(i, -60, i, 60);
+      }
+      for (let z = -55; z <= 60; z += 4) {
+        let first = true;
+        ctx.beginPath();
+        for (let x = -70; x <= 70; x += 3) {
+          const duneY = Math.sin((x + z + world.time * 2) * 0.11) * 0.35 + Math.cos((x - z) * 0.15) * 0.2;
+          const p = projectPoint(x, duneY, z);
+          if (!p) continue;
+          if (first) {
+            ctx.moveTo(p.x, p.y);
+            first = false;
+          } else {
+            ctx.lineTo(p.x, p.y);
+          }
+        }
+        ctx.stroke();
+      }
+    }
+
+    function drawRealisticAlienAgent(r) {
+      const sizePx = r.alien.size * r.p.scale;
+      const glow = Math.min(0.9, 2 / r.p.depth);
+      const dir = Math.cos(r.alien.heading - world.player.yaw);
+      const lean = Math.sin(r.alien.heading - world.player.yaw) * sizePx * 0.06;
+
+      ctx.fillStyle = `rgba(35,27,22,${0.28 + glow * 0.2})`;
+      ctx.beginPath();
+      ctx.ellipse(r.p.x, r.p.y + sizePx * 0.65, sizePx * 0.42, sizePx * 0.13, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      const bodyGrad = ctx.createLinearGradient(r.p.x, r.p.y - sizePx * 0.8, r.p.x, r.p.y + sizePx * 0.4);
+      bodyGrad.addColorStop(0, 'rgba(214,226,235,0.95)');
+      bodyGrad.addColorStop(0.55, 'rgba(148,166,181,0.95)');
+      bodyGrad.addColorStop(1, 'rgba(80,94,109,0.95)');
+      ctx.fillStyle = bodyGrad;
+      ctx.beginPath();
+      ctx.roundRect(r.p.x - sizePx * 0.22 + lean, r.p.y - sizePx * 0.48, sizePx * 0.44, sizePx * 0.72, sizePx * 0.16);
+      ctx.fill();
+
+      ctx.fillStyle = 'rgba(75,93,112,0.95)';
+      const armOffset = r.alien.armSwing * sizePx * 0.15;
+      ctx.fillRect(r.p.x - sizePx * 0.35 + lean, r.p.y - sizePx * 0.4 + armOffset, sizePx * 0.09, sizePx * 0.45);
+      ctx.fillRect(r.p.x + sizePx * 0.26 + lean, r.p.y - sizePx * 0.4 - armOffset, sizePx * 0.09, sizePx * 0.45);
+
+      const legOffset = r.alien.legSwing * sizePx * 0.16;
+      ctx.fillRect(r.p.x - sizePx * 0.15 + lean, r.p.y + sizePx * 0.18 + legOffset, sizePx * 0.1, sizePx * 0.45);
+      ctx.fillRect(r.p.x + sizePx * 0.05 + lean, r.p.y + sizePx * 0.18 - legOffset, sizePx * 0.1, sizePx * 0.45);
+
+      const headGrad = ctx.createRadialGradient(r.p.x + lean - sizePx * 0.05, r.p.y - sizePx * 0.68, sizePx * 0.05, r.p.x + lean, r.p.y - sizePx * 0.63, sizePx * 0.24);
+      headGrad.addColorStop(0, 'rgba(250,252,255,0.98)');
+      headGrad.addColorStop(1, 'rgba(120,140,155,0.95)');
+      ctx.fillStyle = headGrad;
+      ctx.beginPath();
+      ctx.ellipse(r.p.x + lean, r.p.y - sizePx * 0.62, sizePx * 0.2, sizePx * 0.24, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = `rgba(93,255,227,${0.65 + glow * 0.25})`;
+      const eyeSpread = sizePx * 0.06 * (0.5 + Math.max(0.2, dir));
+      const eyeSize = Math.max(1.4, sizePx * 0.02);
+      ctx.beginPath();
+      ctx.arc(r.p.x + lean - eyeSpread, r.p.y - sizePx * 0.64, eyeSize, 0, Math.PI * 2);
+      ctx.arc(r.p.x + lean + eyeSpread, r.p.y - sizePx * 0.64, eyeSize, 0, Math.PI * 2);
+      ctx.fill();
     }
 
     function drawGroundLine(x1, z1, x2, z2) {


### PR DESCRIPTION
### Motivation
- Retheme the game world from a generic arena into a warm "Alien Dessert Rift" to match new visual direction. 
- Make alien NPCs behave and appear more lifelike by adding heading-based steering, limb/gait animation, and local avoidance so agents move realistically.

### Description
- Updated UI/title/copy to reflect the new experience (`title`, main `h1`, overlay mission text in `index.html`).
- Reworked environment rendering by adding warm sky colors, tinted stars, a sand-mist layer (`drawDesertMist`), and layered dune-line ground rendering (`drawDessertDunes`).
- Enhanced alien simulation state and steering by adding spawn properties (`heading`, `vx`, `vz`, `topSpeed`, `turnRate`, `gaitPhase`, etc.) and utility `wrapAngle`, and replacing direct position stepping with heading-based acceleration, velocity damping, and crowd-avoidance in the update loop.
- Replaced the simple blob alien draw path with `drawRealisticAlienAgent`, a new render pass that draws shaded bodies, articulated limbs, head gradients, and reactive eyes; the main render loop now sorts renderables and calls the new agent renderer.

### Testing
- Reviewed the `index.html` diff and validated code paths for the game loop and render functions by inspecting the modified file. 
- Attempted to run a local static server via `python3 -m http.server 4173`, but the background server process could not be kept alive in this execution environment (defunct process observed). 
- Attempted to capture a screenshot with Playwright, but the browser navigation failed with `ERR_EMPTY_RESPONSE` and a subsequent `ERR_FILE_NOT_FOUND` when loading the file directly, so visual runtime validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d60b8c28c832eb2b1319bc382701f)