### PR TITLE
Add agent_manager.sh and README to manage Python AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Galactic-Leap Linux Agent Helper
+
+This repo provides a small Linux utility script to manage a Python-based AI agent service.
+
+## Why your command failed
+
+You ran:
+
+```bash
+nano.app.py
+```
+
+That is treated as a single command name and fails.
+
+Use one of these instead:
+
+```bash
+nano app.py
+# or
+python3 app.py
+```
+
+## Quick start
+
+```bash
+chmod +x agent_manager.sh
+./agent_manager.sh start
+./agent_manager.sh status
+./agent_manager.sh logs
+./agent_manager.sh edit
+./agent_manager.sh restart
+./agent_manager.sh stop
+```
+
+## Defaults used by the script
+
+- `APP_DIR=$HOME/ai-review-analyzer`
+- `VENV_DIR=$HOME/ai-agent-env`
+- `APP_FILE=app.py`
+
+You can override them:
+
+```bash
+APP_DIR=~/my-agent VENV_DIR=~/venvs/agent APP_FILE=main.py ./agent_manager.sh restart
+```

--- a/agent_manager.sh
+++ b/agent_manager.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-$HOME/ai-review-analyzer}"
+VENV_DIR="${VENV_DIR:-$HOME/ai-agent-env}"
+APP_FILE="${APP_FILE:-app.py}"
+PID_PATTERN="python3 ${APP_FILE}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 <start|stop|restart|status|logs|edit>
+
+Environment overrides:
+  APP_DIR   Directory containing your agent project (default: $HOME/ai-review-analyzer)
+  VENV_DIR  Python virtual environment directory (default: $HOME/ai-agent-env)
+  APP_FILE  Entry-point file (default: app.py)
+USAGE
+}
+
+ensure_paths() {
+  if [[ ! -d "$APP_DIR" ]]; then
+    echo "[ERROR] APP_DIR does not exist: $APP_DIR" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$APP_DIR/$APP_FILE" ]]; then
+    echo "[ERROR] App file not found: $APP_DIR/$APP_FILE" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$VENV_DIR/bin/activate" ]]; then
+    echo "[ERROR] Virtual environment activate script not found: $VENV_DIR/bin/activate" >&2
+    exit 1
+  fi
+}
+
+stop_agent() {
+  if pgrep -f "$PID_PATTERN" >/dev/null; then
+    pkill -f "$PID_PATTERN"
+    echo "[OK] Stopped running agent process(es): $PID_PATTERN"
+  else
+    echo "[OK] No running process matched: $PID_PATTERN"
+  fi
+}
+
+start_agent() {
+  ensure_paths
+  cd "$APP_DIR"
+  # shellcheck disable=SC1090
+  source "$VENV_DIR/bin/activate"
+  nohup python3 "$APP_FILE" > agent.log 2>&1 &
+  sleep 1
+  if pgrep -f "$PID_PATTERN" >/dev/null; then
+    echo "[OK] Agent started. Logs: $APP_DIR/agent.log"
+  else
+    echo "[ERROR] Agent failed to start. Check log: $APP_DIR/agent.log" >&2
+    exit 1
+  fi
+}
+
+status_agent() {
+  if pgrep -af "$PID_PATTERN" >/dev/null; then
+    echo "[OK] Agent is running:"
+    pgrep -af "$PID_PATTERN"
+  else
+    echo "[OK] Agent is not running"
+  fi
+}
+
+logs_agent() {
+  ensure_paths
+  touch "$APP_DIR/agent.log"
+  tail -n 50 -f "$APP_DIR/agent.log"
+}
+
+edit_app() {
+  ensure_paths
+  local editor="${EDITOR:-nano}"
+  "$editor" "$APP_DIR/$APP_FILE"
+}
+
+main() {
+  case "${1:-}" in
+    start)
+      start_agent
+      ;;
+    stop)
+      stop_agent
+      ;;
+    restart)
+      stop_agent
+      start_agent
+      ;;
+    status)
+      status_agent
+      ;;
+    logs)
+      logs_agent
+      ;;
+    edit)
+      edit_app
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation

- Provide a simple Linux helper to manage a Python-based AI agent with common actions (`start`, `stop`, `restart`, `status`, `logs`, `edit`).
- Ensure safe launch by validating project and virtualenv paths and by activating the venv before starting the app.
- Document correct usage and fix the common `nano.app.py` typo with a short README.

### Description

- Add `agent_manager.sh`, a POSIX-style management script that supports `start|stop|restart|status|logs|edit`, validates `APP_DIR`, `VENV_DIR`, and `APP_FILE`, and uses `nohup` to background the agent. 
- Add environment variable overrides `APP_DIR`, `VENV_DIR`, and `APP_FILE` with sane defaults (`$HOME/ai-review-analyzer`, `$HOME/ai-agent-env`, `app.py`).
- Add `README.md` with quick-start usage examples and an explanation of the `nano.app.py` typo vs `nano app.py`.
- Make `agent_manager.sh` executable and include basic inline usage/help output.

### Testing

- Ran `bash -n agent_manager.sh` to validate the script syntax and it completed successfully. 
- Ran `./agent_manager.sh status` and received the expected status output (`[OK] Agent is not running`).
- Ran `./agent_manager.sh >/tmp/agent_usage.txt 2>&1 || true; cat /tmp/agent_usage.txt` and verified the usage help text prints as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699133fe7b90832e84f59a04ce7c0417)