### PR TITLE
Add Mini Me Life Forecaster: UI, forecasting engine, styles, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Then open `http://localhost:4173`.
 
 ```bash
 node tests/forecaster.test.js
+node tests/merge-readiness.test.js
 ```
+
+The merge-readiness check verifies that the static entrypoint still references its assets, the agent council export is present, and no conflict markers remain in tracked app files.
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
-# Autonomous AI Holographic Website
+# Mini Me Life Forecaster
 
-A single-page autonomous AI concept site with:
+A polished, privacy-first, browser-based "mini you" that turns a short personal data journal into a seven-day life forecast. It runs entirely in the browser: no accounts, no server, and no data leaves the page.
 
-- Complex animated 3D holographic geometry (Three.js)
-- Futuristic HUD panel
-- Self-learning local chat memory persisted in browser localStorage
+## Highlights
+
+- Interactive signal journal for mood, energy, focus, sleep, stress, social battery, commitments, habits, and goals.
+- Local heuristic persona model with resilience, load, pressure, recovery, and archetype scoring.
+- Cinematic dashboard with KPI cards, trajectory visualization, weekly plan cards, contextual recommendations, and a four-agent planning council.
+- Self-contained static app with a small Node test suite for the forecasting engine and agent outputs.
 
 ## Run locally
+
+Open `index.html` in any modern browser, or serve the folder:
 
 ```bash
 python3 -m http.server 4173
 ```
 
-Open `http://localhost:4173`.
+Then open `http://localhost:4173`.
+
+## Test
+
+```bash
+node tests/forecaster.test.js
+```
+
+## Note
+
+This is a reflective planning tool, not medical, legal, financial, or mental-health advice. Predictions are heuristic and should be treated as prompts for planning rather than facts.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,65 @@
+const form = document.querySelector('#signal-form');
+const forecast = document.querySelector('#forecast');
+const personaSummary = document.querySelector('#persona-summary');
+const metrics = document.querySelector('#metrics');
+const trajectory = document.querySelector('#trajectory');
+const recommendations = document.querySelector('#recommendations');
+const agentCouncil = document.querySelector('#agent-council');
+
+for (const input of form.querySelectorAll('input[type="range"]')) {
+  const output = document.querySelector(`#${input.name}-value`);
+  input.addEventListener('input', () => {
+    output.textContent = input.value;
+    renderPrediction(MiniMeForecaster.predictWeek(formData()));
+  });
+}
+
+for (const field of form.querySelectorAll('textarea')) {
+  field.addEventListener('input', () => renderPrediction(MiniMeForecaster.predictWeek(formData())));
+}
+
+function formData() {
+  return Object.fromEntries(new FormData(form).entries());
+}
+
+function renderPrediction(prediction) {
+  const { persona } = prediction;
+  personaSummary.textContent = prediction.summary;
+  metrics.innerHTML = [
+    ['Resilience', persona.resilience],
+    ['Load', persona.load],
+    ['Clarity', persona.clarity],
+    ['Adapt', persona.adaptability],
+    ['Average', prediction.average],
+  ].map(([label, value]) => `<article><strong>${value}</strong><span>${label}</span></article>`).join('');
+  trajectory.innerHTML = prediction.days.map((day) => `<span style="--height:${day.score * 9}%" title="${day.day}: ${day.score}/10"><b>${day.day.slice(0, 3)}</b></span>`).join('');
+  agentCouncil.innerHTML = `<h3>Agent council</h3><div>${prediction.agents.map((agent) => `<article class="agent-card"><strong>${agent.icon} ${agent.name}</strong><span>${agent.priority}</span><p>${agent.assignment}</p><small>${agent.specialty}</small></article>`).join('')}</div>`;
+  recommendations.innerHTML = `<h3>Smart nudges</h3><ul>${prediction.recommendations.map((item) => `<li>${item}</li>`).join('')}</ul>`;
+  forecast.innerHTML = `
+    <div class="forecast-header">
+      <p class="eyebrow">Next seven days</p>
+      <h2>${prediction.outlook}</h2>
+      <p>${prediction.summary}</p>
+    </div>
+    <div class="day-grid">
+      ${prediction.days.map((day) => `
+        <article class="day-card">
+          <div class="day-topline"><h3>${day.day}</h3><span>${day.confidence}%</span></div>
+          <meter min="1" max="10" value="${day.score}"></meter>
+          <p class="theme">${day.theme} · ${day.score}/10</p>
+          <p><strong>Do:</strong> ${day.action}</p>
+          <p><strong>Watch:</strong> ${day.risk}</p>
+          <p><strong>Agent:</strong> ${day.agent}</p>
+          <p class="note">${day.note}</p>
+        </article>
+      `).join('')}
+    </div>`;
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  renderPrediction(MiniMeForecaster.predictWeek(formData()));
+  forecast.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+renderPrediction(MiniMeForecaster.predictWeek(formData()));

--- a/forecaster.js
+++ b/forecaster.js
@@ -1,0 +1,197 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.MiniMeForecaster = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+  const PRESSURE_WORDS = ['due', 'exam', 'interview', 'deadline', 'presentation', 'project', 'test', 'launch', 'review'];
+  const RECOVERY_WORDS = ['rest', 'sleep', 'break', 'family', 'friend', 'gym', 'walk', 'therapy', 'meditate', 'stretch'];
+  const HABIT_WORDS = ['exercise', 'journal', 'read', 'hydrate', 'study', 'code', 'cook', 'budget'];
+
+  const AGENTS = [
+    {
+      id: 'strategist',
+      name: 'Strategy Agent',
+      icon: '♟',
+      specialty: 'chooses the highest-leverage move',
+      advice(persona, day) {
+        return day.score >= 6.7
+          ? 'Schedule the most consequential goal during your peak-energy block.'
+          : 'Define a tiny win before noon so the day has traction even if energy fluctuates.';
+      },
+    },
+    {
+      id: 'wellbeing',
+      name: 'Wellbeing Agent',
+      icon: '✦',
+      specialty: 'protects recovery and emotional bandwidth',
+      advice(persona) {
+        if (persona.signals.sleep < 6.5) return 'Treat sleep as the keystone metric; your forecast improves fastest there.';
+        if (persona.load >= 7) return 'Add one deliberate decompression ritual after the highest-pressure commitment.';
+        return 'Keep a recovery pocket on the calendar so momentum stays sustainable.';
+      },
+    },
+    {
+      id: 'focus',
+      name: 'Focus Agent',
+      icon: '◎',
+      specialty: 'removes distraction and builds deep-work rails',
+      advice(persona) {
+        return persona.clarity >= 6.5
+          ? 'Use a 50-minute deep-work sprint and make your phone physically inconvenient.'
+          : 'Write the first visible next action before opening any feed or inbox.';
+      },
+    },
+    {
+      id: 'social',
+      name: 'Connection Agent',
+      icon: '◌',
+      specialty: 'balances people, boundaries, and support',
+      advice(persona) {
+        return persona.signals.social >= 7
+          ? 'Use your social battery intentionally: ask for help, accountability, or celebration.'
+          : 'Protect a low-friction boundary and choose one relationship touchpoint that feels nourishing.';
+      },
+    },
+  ];
+
+  function clamp(value, min, max) {
+    const number = Number(value);
+    if (Number.isNaN(number)) return min;
+    return Math.min(max, Math.max(min, number));
+  }
+
+  function parseKeywords(text) {
+    return String(text || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean);
+  }
+
+  function countMatches(words, dictionary) {
+    return words.filter((word) => dictionary.includes(word)).length;
+  }
+
+  function buildPersona(input) {
+    const signals = {
+      mood: clamp(input.mood, 1, 10),
+      energy: clamp(input.energy, 1, 10),
+      focus: clamp(input.focus, 1, 10),
+      sleep: clamp(input.sleep, 3, 10),
+      stress: clamp(input.stress, 1, 10),
+      social: clamp(input.social, 1, 10),
+    };
+    const commitments = parseKeywords(input.commitments);
+    const goals = parseKeywords(input.goals);
+    const habits = parseKeywords(input.habits);
+    const allWords = commitments.concat(goals, habits);
+    const pressure = countMatches(commitments, PRESSURE_WORDS);
+    const recovery = countMatches(allWords, RECOVERY_WORDS);
+    const habitSupport = countMatches(allWords, HABIT_WORDS);
+    const sleepDebt = Math.max(0, 7 - signals.sleep);
+    const resilience = (signals.mood + signals.energy + signals.focus + signals.sleep + signals.social) / 5
+      - signals.stress * 0.42
+      + recovery * 0.24
+      + habitSupport * 0.16;
+    const load = signals.stress + pressure * 1.2 + sleepDebt * 0.72 + Math.max(0, commitments.length - 12) * 0.05;
+    const clarity = clamp((signals.focus + signals.energy + habitSupport) / 3, 1, 10);
+    const adaptability = clamp((signals.mood + signals.social + recovery + habitSupport) / 3.2, 1, 10);
+    return {
+      signals,
+      commitments,
+      goals,
+      habits,
+      pressure,
+      recovery,
+      habitSupport,
+      clarity: Number(clarity.toFixed(2)),
+      adaptability: Number(adaptability.toFixed(2)),
+      resilience: Number(clamp(resilience, 1, 10).toFixed(2)),
+      load: Number(clamp(load, 1, 10).toFixed(2)),
+      archetype: resilience >= 6.8 ? 'Momentum Builder' : load >= 7 ? 'Careful Recharger' : clarity >= 6.3 ? 'Focused Improver' : 'Steady Improver',
+    };
+  }
+
+  function scoreDay(persona, index) {
+    const weekendBoost = index >= 5 ? 0.85 : 0;
+    const mondayRamp = index === 0 ? -0.18 : 0;
+    const midweekDip = index === 2 || index === 3 ? -0.34 : 0;
+    const pressureSpike = persona.pressure > 0 && index >= 2 && index <= 4 ? persona.pressure * -0.26 : 0;
+    const habitLift = persona.habitSupport > 0 && [1, 4, 6].includes(index) ? 0.22 : 0;
+    const base = persona.resilience - persona.load * 0.17 + weekendBoost + mondayRamp + midweekDip + pressureSpike + habitLift;
+    return clamp(Number(base.toFixed(2)), 1, 10);
+  }
+
+  function makeDay(persona, index) {
+    const score = scoreDay(persona, index);
+    const day = DAYS[index];
+    const high = score >= 7;
+    const low = score < 4.5;
+    const theme = high ? 'high-output day' : low ? 'recovery and simplification day' : 'balanced progress day';
+    const action = high
+      ? 'Use your strongest block for the goal that matters most.'
+      : low
+        ? 'Shrink the plan to essentials and protect sleep.'
+        : 'Make steady progress with one focused task and one reset break.';
+    const risk = persona.load > 7
+      ? 'Overcommitting because your load is already elevated.'
+      : persona.signals.sleep < 6
+        ? 'Low sleep may reduce patience and focus.'
+        : 'Drifting without a clear first task.';
+    return {
+      day,
+      score,
+      confidence: clamp(Math.round(54 + Math.abs(score - 5) * 7 + persona.commitments.length * 1.4 + persona.habitSupport), 45, 88),
+      theme,
+      action,
+      risk,
+      agent: AGENTS[index % AGENTS.length].name,
+      note: `Mini-you says: treat ${day} like a ${theme}; your best move is to ${action.toLowerCase()}`,
+    };
+  }
+
+  function makeRecommendations(persona) {
+    const recommendations = [];
+    if (persona.load >= 7) recommendations.push('Create a not-to-do list before adding another commitment.');
+    if (persona.signals.sleep < 6.5) recommendations.push('Move bedtime 30 minutes earlier for two nights and reduce late caffeine.');
+    if (persona.pressure > 1) recommendations.push('Pre-decide the first 25-minute work sprint for your highest-pressure item.');
+    if (persona.recovery < 1) recommendations.push('Schedule one deliberate recovery block so the week has a reset valve.');
+    if (!recommendations.length) recommendations.push('Protect your current rhythm and use the extra margin for one meaningful stretch goal.');
+    return recommendations;
+  }
+
+  function runAgents(persona, days) {
+    return AGENTS.map((agent, index) => {
+      const day = days[index + 1] || days[0];
+      const priority = agent.id === 'wellbeing' && persona.load >= 7 ? 'critical' : day.score >= 6.5 ? 'accelerate' : 'stabilize';
+      return {
+        id: agent.id,
+        name: agent.name,
+        icon: agent.icon,
+        specialty: agent.specialty,
+        priority,
+        assignment: agent.advice(persona, day),
+      };
+    });
+  }
+
+  function predictWeek(input) {
+    const persona = buildPersona(input);
+    const days = DAYS.map((_, index) => makeDay(persona, index));
+    const average = days.reduce((sum, day) => sum + day.score, 0) / days.length;
+    const agents = runAgents(persona, days);
+    return {
+      persona,
+      summary: `You look like a ${persona.archetype}: resilience ${persona.resilience}/10, load ${persona.load}/10, clarity ${persona.clarity}/10, with ${persona.pressure} pressure signal(s), ${persona.recovery} recovery signal(s), and ${persona.habitSupport} habit anchor(s).`,
+      outlook: average >= 6.5 ? 'Positive momentum' : average < 4.8 ? 'Conserve energy' : 'Manageable with structure',
+      average: Number(average.toFixed(2)),
+      recommendations: makeRecommendations(persona),
+      agents,
+      days,
+    };
+  }
+
+  return { buildPersona, predictWeek, parseKeywords, runAgents };
+});

--- a/index.html
+++ b/index.html
@@ -1,444 +1,51 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Autonomous AI Holographic Interface</title>
-    <style>
-      :root {
-        --bg: #050713;
-        --panel: rgba(9, 16, 35, 0.7);
-        --border: rgba(92, 238, 255, 0.45);
-        --text: #e7f9ff;
-        --accent: #3df0ff;
-        --accent-2: #a05dff;
-        --warning: #ff9ecf;
-      }
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mini Me Life Forecaster</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="orb orb-one"></div>
+  <div class="orb orb-two"></div>
+  <main class="app-shell">
+    <section class="hero">
+      <p class="eyebrow">Private • local • instant</p>
+      <h1>Meet the mini you that forecasts your next week.</h1>
+      <p class="lede">Turn mood, energy, commitments, habits, and goals into an agent-powered seven-day operating plan — without sending a single byte off your device.</p>
+      <div class="hero-actions"><a href="#signal-form">Build my forecast</a><span>4 specialist agents • no signup • no cloud</span></div>
+      <div class="agent-marquee" aria-label="AI agent team preview"><span>Strategy Agent</span><span>Wellbeing Agent</span><span>Focus Agent</span><span>Connection Agent</span></div>
+    </section>
 
-      * {
-        box-sizing: border-box;
-      }
+    <section class="workspace" aria-labelledby="input-heading">
+      <form id="signal-form" class="control-panel">
+        <div><p class="eyebrow">Signal journal</p><h2 id="input-heading">Tune your current reality</h2></div>
+        <label>Mood <span id="mood-value">6</span><input name="mood" type="range" min="1" max="10" value="6" /></label>
+        <label>Energy <span id="energy-value">6</span><input name="energy" type="range" min="1" max="10" value="6" /></label>
+        <label>Focus <span id="focus-value">6</span><input name="focus" type="range" min="1" max="10" value="6" /></label>
+        <label>Sleep hours <span id="sleep-value">7</span><input name="sleep" type="range" min="3" max="10" value="7" step="0.5" /></label>
+        <label>Stress <span id="stress-value">4</span><input name="stress" type="range" min="1" max="10" value="4" /></label>
+        <label>Social battery <span id="social-value">6</span><input name="social" type="range" min="1" max="10" value="6" /></label>
+        <label for="commitments">Upcoming commitments<textarea id="commitments" name="commitments" rows="4" placeholder="Project due Thursday, gym 3x, family dinner, job interview"></textarea></label>
+        <label for="goals">Main goals<textarea id="goals" name="goals" rows="3" placeholder="Finish essay, sleep earlier, save money, practice coding"></textarea></label>
+        <label for="habits">Habit anchors<textarea id="habits" name="habits" rows="2" placeholder="Exercise, journal, hydrate, read"></textarea></label>
+        <button type="submit">Forecast my week</button>
+      </form>
 
-      body {
-        margin: 0;
-        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
-        background: radial-gradient(circle at 20% 20%, #132248 0%, #050713 45%, #02030b 100%);
-        color: var(--text);
-        min-height: 100vh;
-        overflow: hidden;
-      }
-
-      #app {
-        display: grid;
-        grid-template-columns: 1.6fr 1fr;
-        width: 100vw;
-        height: 100vh;
-      }
-
-      #scene {
-        position: relative;
-      }
-
-      #scene::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: radial-gradient(circle at center, transparent 40%, rgba(4, 7, 16, 0.75));
-        pointer-events: none;
-      }
-
-      .hud {
-        display: flex;
-        flex-direction: column;
-        border-left: 1px solid var(--border);
-        background: linear-gradient(170deg, rgba(11, 18, 40, 0.85), rgba(4, 10, 24, 0.85));
-        backdrop-filter: blur(14px);
-      }
-
-      .hud-header {
-        padding: 1rem 1.2rem 0.65rem;
-        border-bottom: 1px solid rgba(143, 231, 255, 0.25);
-      }
-
-      h1 {
-        margin: 0;
-        font-size: 1.1rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--accent);
-      }
-
-      .status {
-        margin-top: 0.35rem;
-        font-size: 0.8rem;
-        opacity: 0.8;
-      }
-
-      .chat-log {
-        flex: 1;
-        overflow-y: auto;
-        padding: 1rem 1.2rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.8rem;
-      }
-
-      .message {
-        padding: 0.75rem 0.9rem;
-        border: 1px solid rgba(121, 213, 255, 0.28);
-        border-radius: 0.7rem;
-        line-height: 1.35;
-        box-shadow: 0 0 0.8rem rgba(60, 150, 255, 0.08);
-      }
-
-      .message.user {
-        align-self: flex-end;
-        border-color: rgba(160, 93, 255, 0.5);
-        background: rgba(89, 39, 153, 0.25);
-      }
-
-      .message.ai {
-        align-self: flex-start;
-        border-color: rgba(61, 240, 255, 0.5);
-        background: rgba(10, 101, 119, 0.25);
-      }
-
-      .message small {
-        display: block;
-        margin-top: 0.25rem;
-        opacity: 0.7;
-      }
-
-      .composer {
-        border-top: 1px solid rgba(143, 231, 255, 0.25);
-        padding: 0.9rem 1.2rem 1.2rem;
-      }
-
-      .composer form {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        gap: 0.65rem;
-      }
-
-      input[type="text"] {
-        width: 100%;
-        border: 1px solid rgba(137, 217, 255, 0.35);
-        background: rgba(6, 17, 40, 0.75);
-        color: var(--text);
-        border-radius: 0.6rem;
-        padding: 0.75rem 0.85rem;
-        outline: none;
-      }
-
-      input[type="text"]:focus {
-        border-color: var(--accent);
-        box-shadow: 0 0 0.9rem rgba(61, 240, 255, 0.35);
-      }
-
-      button {
-        border: 1px solid rgba(61, 240, 255, 0.7);
-        background: linear-gradient(135deg, rgba(24, 146, 173, 0.9), rgba(84, 49, 184, 0.85));
-        color: white;
-        border-radius: 0.6rem;
-        padding: 0.75rem 1rem;
-        cursor: pointer;
-        font-weight: 600;
-      }
-
-      .memory {
-        margin-top: 0.7rem;
-        font-size: 0.75rem;
-        color: var(--warning);
-      }
-
-      @media (max-width: 980px) {
-        #app {
-          grid-template-columns: 1fr;
-          grid-template-rows: 52vh 48vh;
-        }
-
-        .hud {
-          border-left: none;
-          border-top: 1px solid var(--border);
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <main id="app">
-      <section id="scene"></section>
-      <aside class="hud">
-        <div class="hud-header">
-          <h1>Autonomous AI Core</h1>
-          <div class="status" id="status">Learning profile: warming up…</div>
-        </div>
-        <div class="chat-log" id="chatLog"></div>
-        <div class="composer">
-          <form id="chatForm">
-            <input id="userInput" type="text" placeholder="Train the AI with your message…" autocomplete="off" required />
-            <button type="submit">Transmit</button>
-          </form>
-          <div class="memory" id="memoryInfo"></div>
-        </div>
+      <aside class="dashboard" aria-live="polite">
+        <div class="mini-you"><div class="avatar">ME</div><div><p class="eyebrow">Persona model</p><h2>Your mini-you</h2></div></div>
+        <p id="persona-summary">Waiting for your data. I will summarize your pattern here.</p>
+        <div class="metrics" id="metrics"></div>
+        <div class="trajectory" id="trajectory" aria-label="Weekly score trajectory"></div>
+        <div class="agent-council" id="agent-council"></div>
+        <div class="recommendations" id="recommendations"></div>
       </aside>
-    </main>
+    </section>
 
-    <script type="module">
-      import * as THREE from "https://unpkg.com/three@0.162.0/build/three.module.js";
-
-      const sceneHost = document.getElementById("scene");
-      const chatLog = document.getElementById("chatLog");
-      const chatForm = document.getElementById("chatForm");
-      const userInput = document.getElementById("userInput");
-      const statusEl = document.getElementById("status");
-      const memoryInfoEl = document.getElementById("memoryInfo");
-
-      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-      renderer.setSize(sceneHost.clientWidth, sceneHost.clientHeight);
-      sceneHost.appendChild(renderer.domElement);
-
-      const scene = new THREE.Scene();
-      const camera = new THREE.PerspectiveCamera(48, sceneHost.clientWidth / sceneHost.clientHeight, 0.1, 100);
-      camera.position.set(0, 1.2, 8.6);
-
-      const ambient = new THREE.AmbientLight(0x88b6ff, 0.85);
-      scene.add(ambient);
-
-      const keyLight = new THREE.PointLight(0x4af3ff, 2.1, 30);
-      keyLight.position.set(6, 5, 4);
-      scene.add(keyLight);
-
-      const backLight = new THREE.PointLight(0x9e6dff, 1.9, 28);
-      backLight.position.set(-6, -3, -4);
-      scene.add(backLight);
-
-      const holoGroup = new THREE.Group();
-      scene.add(holoGroup);
-
-      const shapeConfigs = [
-        { geo: new THREE.IcosahedronGeometry(1.35, 1), pos: [-2.4, 0, 0], color: 0x3df0ff },
-        { geo: new THREE.TorusKnotGeometry(0.85, 0.24, 210, 20), pos: [0, 0.15, 0], color: 0xa05dff },
-        { geo: new THREE.OctahedronGeometry(1.15, 2), pos: [2.4, -0.1, 0], color: 0x71ffe6 }
-      ];
-
-      const holograms = shapeConfigs.map(({ geo, pos, color }, idx) => {
-        const wire = new THREE.LineSegments(
-          new THREE.WireframeGeometry(geo),
-          new THREE.LineBasicMaterial({
-            color,
-            transparent: true,
-            opacity: 0.85
-          })
-        );
-
-        wire.position.set(...pos);
-
-        const shell = new THREE.Mesh(
-          geo,
-          new THREE.MeshPhysicalMaterial({
-            color,
-            emissive: color,
-            emissiveIntensity: 0.24,
-            transparent: true,
-            opacity: 0.14,
-            roughness: 0.04,
-            metalness: 0.18,
-            transmission: 0.94,
-            clearcoat: 1
-          })
-        );
-
-        shell.position.copy(wire.position);
-        shell.scale.multiplyScalar(1.045);
-
-        const pulseRing = new THREE.Mesh(
-          new THREE.TorusGeometry(1.7 + idx * 0.22, 0.018, 12, 92),
-          new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.42 })
-        );
-
-        pulseRing.rotation.x = Math.PI / 2;
-        pulseRing.position.y = -1.55 + idx * 0.16;
-
-        holoGroup.add(wire, shell, pulseRing);
-        return { wire, shell, pulseRing, speed: 0.0035 + idx * 0.0017 };
-      });
-
-      const stars = new THREE.Points(
-        new THREE.BufferGeometry(),
-        new THREE.PointsMaterial({ color: 0x6de7ff, size: 0.045, transparent: true, opacity: 0.8 })
-      );
-
-      const starCount = 950;
-      const starPos = new Float32Array(starCount * 3);
-      for (let i = 0; i < starCount; i++) {
-        starPos[i * 3] = (Math.random() - 0.5) * 34;
-        starPos[i * 3 + 1] = (Math.random() - 0.5) * 22;
-        starPos[i * 3 + 2] = (Math.random() - 0.5) * 30;
-      }
-      stars.geometry.setAttribute("position", new THREE.BufferAttribute(starPos, 3));
-      scene.add(stars);
-
-      const defaultBrain = {
-        memory: {
-          "hello": [
-            "Hello operator. I am syncing your autonomous control layer.",
-            "Greetings. System awareness calibrated and listening."
-          ],
-          "ai": [
-            "My self-learning layer stores useful user patterns to improve future responses.",
-            "I evolve by remembering pairings between your prompts and my generated intent."
-          ],
-          "hologram": [
-            "The geometric cores are live. Their phase velocity is tied to chat intensity.",
-            "Holographic field stable. I can increase rotational complexity if needed."
-          ],
-          "default": [
-            "I have logged this message and adapted my response matrix.",
-            "Interesting input. I am integrating it into long-term behavior memory."
-          ]
-        },
-        interactions: 0,
-        learnedPairs: []
-      };
-
-      let brain = loadBrain();
-      refreshMemoryInfo();
-
-      addMessage("ai", "Autonomous AI initialized. Teach me by chatting; I persist memory locally.");
-
-      chatForm.addEventListener("submit", (event) => {
-        event.preventDefault();
-        const prompt = userInput.value.trim();
-        if (!prompt) return;
-
-        addMessage("user", prompt);
-        const response = generateResponse(prompt);
-        addMessage("ai", response);
-
-        learnFrom(prompt, response);
-        userInput.value = "";
-      });
-
-      function loadBrain() {
-        try {
-          const cached = localStorage.getItem("autonomous-ai-brain-v1");
-          if (!cached) return structuredClone(defaultBrain);
-          const parsed = JSON.parse(cached);
-          return {
-            memory: { ...defaultBrain.memory, ...(parsed.memory || {}) },
-            interactions: Number(parsed.interactions || 0),
-            learnedPairs: Array.isArray(parsed.learnedPairs) ? parsed.learnedPairs.slice(-120) : []
-          };
-        } catch {
-          return structuredClone(defaultBrain);
-        }
-      }
-
-      function saveBrain() {
-        localStorage.setItem("autonomous-ai-brain-v1", JSON.stringify(brain));
-      }
-
-      function tokenize(text) {
-        return text.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
-      }
-
-      function generateResponse(input) {
-        const terms = tokenize(input);
-        const dynamicResponses = [];
-
-        for (const term of terms) {
-          if (brain.memory[term]) {
-            dynamicResponses.push(...brain.memory[term]);
-          }
-        }
-
-        if (brain.learnedPairs.length) {
-          const related = brain.learnedPairs
-            .filter((pair) => terms.some((term) => pair.inputTokens.includes(term)))
-            .slice(-3)
-            .map((pair) => pair.response);
-          dynamicResponses.push(...related);
-        }
-
-        const fallbacks = brain.memory.default;
-        const source = dynamicResponses.length ? dynamicResponses : fallbacks;
-        const picked = source[Math.floor(Math.random() * source.length)];
-
-        brain.interactions += 1;
-        statusEl.textContent = `Learning profile: ${brain.interactions} interactions processed`;
-        return picked;
-      }
-
-      function learnFrom(input, response) {
-        const tokens = tokenize(input);
-        tokens.forEach((token) => {
-          if (!brain.memory[token]) {
-            brain.memory[token] = [
-              `I have now learned the concept "${token}" from your training data.`
-            ];
-          } else if (brain.memory[token].length < 6) {
-            brain.memory[token].push(`Refined "${token}" context captured at interaction ${brain.interactions}.`);
-          }
-        });
-
-        brain.learnedPairs.push({
-          inputTokens: tokens,
-          response
-        });
-
-        brain.learnedPairs = brain.learnedPairs.slice(-120);
-        saveBrain();
-        refreshMemoryInfo();
-      }
-
-      function refreshMemoryInfo() {
-        const learnedTerms = Object.keys(brain.memory).length;
-        memoryInfoEl.textContent = `${learnedTerms} concepts in memory • ${brain.learnedPairs.length} learned conversational links`;
-      }
-
-      function addMessage(role, content) {
-        const node = document.createElement("article");
-        node.className = `message ${role}`;
-        const time = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-        node.innerHTML = `${content}<small>${role.toUpperCase()} • ${time}</small>`;
-        chatLog.appendChild(node);
-        chatLog.scrollTop = chatLog.scrollHeight;
-      }
-
-      function animate() {
-        requestAnimationFrame(animate);
-        const t = performance.now() * 0.001;
-
-        holograms.forEach(({ wire, shell, pulseRing, speed }, idx) => {
-          wire.rotation.x += speed;
-          wire.rotation.y += speed * (1.2 + idx * 0.2);
-
-          shell.rotation.x -= speed * 0.9;
-          shell.rotation.z += speed * 1.15;
-
-          const pulse = 1 + Math.sin(t * (1.6 + idx * 0.35)) * 0.1;
-          pulseRing.scale.setScalar(pulse);
-          pulseRing.material.opacity = 0.18 + Math.abs(Math.sin(t * 2 + idx)) * 0.36;
-        });
-
-        holoGroup.rotation.y = Math.sin(t * 0.24) * 0.28;
-        holoGroup.position.y = Math.sin(t * 0.8) * 0.2;
-
-        stars.rotation.y += 0.00065;
-        stars.rotation.x = Math.sin(t * 0.1) * 0.1;
-
-        renderer.render(scene, camera);
-      }
-
-      animate();
-
-      window.addEventListener("resize", () => {
-        const { clientWidth, clientHeight } = sceneHost;
-        renderer.setSize(clientWidth, clientHeight);
-        camera.aspect = clientWidth / clientHeight;
-        camera.updateProjectionMatrix();
-      });
-    </script>
-  </body>
+    <section id="forecast" class="forecast" aria-live="polite"></section>
+  </main>
+  <script src="forecaster.js"></script>
+  <script src="app.js"></script>
+</body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,77 @@
+:root {
+  color-scheme: dark;
+  --bg: #080a18;
+  --panel: rgba(255, 255, 255, 0.09);
+  --panel-strong: rgba(255, 255, 255, 0.15);
+  --line: rgba(255, 255, 255, 0.18);
+  --text: #f8fbff;
+  --muted: #b8c3e8;
+  --mint: #8dffd1;
+  --blue: #89b7ff;
+  --pink: #ff8fd8;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; min-height: 100vh; overflow-x: hidden; background: radial-gradient(circle at 15% 10%, #384bff66, transparent 30rem), radial-gradient(circle at 85% 0%, #ff5ad855, transparent 28rem), linear-gradient(135deg, #070816, #111632 48%, #090b17); }
+body::before { content: ""; position: fixed; inset: 0; pointer-events: none; background-image: linear-gradient(#ffffff08 1px, transparent 1px), linear-gradient(90deg, #ffffff08 1px, transparent 1px); background-size: 52px 52px; mask-image: linear-gradient(to bottom, black, transparent 82%); }
+.orb { position: fixed; width: 22rem; aspect-ratio: 1; border-radius: 999px; filter: blur(38px); opacity: 0.45; pointer-events: none; animation: float 12s ease-in-out infinite; }
+.orb-one { left: -7rem; top: 18rem; background: var(--mint); }
+.orb-two { right: -8rem; top: 8rem; background: var(--pink); animation-delay: -5s; }
+.app-shell { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0; position: relative; }
+.hero { min-height: 58vh; display: grid; place-items: center; text-align: center; align-content: center; gap: 20px; }
+.eyebrow { margin: 0; color: var(--mint); text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.76rem; font-weight: 900; }
+h1 { max-width: 1000px; margin: 0; font-size: clamp(3.2rem, 9vw, 8rem); line-height: 0.84; letter-spacing: -0.09em; text-wrap: balance; }
+h2 { margin: 0; font-size: clamp(1.5rem, 3vw, 2.5rem); letter-spacing: -0.04em; }
+h3 { margin: 0 0 10px; }
+.lede { max-width: 760px; margin: 0 auto; color: var(--muted); font-size: clamp(1rem, 2vw, 1.35rem); line-height: 1.7; }
+.hero-actions { display: flex; gap: 18px; justify-content: center; align-items: center; flex-wrap: wrap; color: var(--muted); }
+.hero-actions a, button { border: 0; border-radius: 999px; padding: 15px 22px; color: #08101c; background: linear-gradient(135deg, var(--mint), var(--blue)); box-shadow: 0 20px 70px #8dffd133; font: inherit; font-weight: 950; text-decoration: none; cursor: pointer; }
+.workspace { display: grid; grid-template-columns: minmax(320px, 0.85fr) minmax(0, 1.15fr); gap: 22px; align-items: start; }
+.control-panel, .dashboard, .forecast-header, .day-card { border: 1px solid var(--line); background: linear-gradient(145deg, var(--panel-strong), var(--panel)); border-radius: 34px; box-shadow: 0 30px 100px #0008; backdrop-filter: blur(22px); }
+.control-panel { display: grid; gap: 17px; padding: 26px; }
+label { display: grid; gap: 9px; color: #edf3ff; font-weight: 850; }
+label span { color: var(--mint); justify-self: end; margin-top: -1.7rem; }
+input, textarea { width: 100%; border: 1px solid #ffffff22; border-radius: 18px; font: inherit; }
+input[type='range'] { accent-color: var(--mint); }
+textarea { min-height: 92px; resize: vertical; padding: 14px; color: var(--text); background: rgba(4, 8, 24, 0.72); outline: none; }
+textarea:focus { border-color: var(--mint); box-shadow: 0 0 0 4px #8dffd11f; }
+.dashboard { position: sticky; top: 22px; padding: 28px; }
+.mini-you { display: flex; gap: 16px; align-items: center; margin-bottom: 18px; }
+.avatar { display: grid; place-items: center; width: 86px; height: 86px; border-radius: 28px; background: radial-gradient(circle at 35% 20%, white, var(--mint) 22%, #3446ff 64%, #15172b); color: #08101c; font-size: 2rem; font-weight: 1000; box-shadow: inset 0 0 30px #fff8, 0 0 55px #8dffd155; }
+#persona-summary, .forecast-header p, .day-card p { color: var(--muted); line-height: 1.55; }
+.metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 12px; margin: 22px 0; }
+.metrics article { padding: 16px; border-radius: 22px; background: rgba(255,255,255,0.09); border: 1px solid var(--line); }
+.metrics strong { display: block; font-size: 1.8rem; color: var(--mint); }
+.metrics span { color: var(--muted); font-size: 0.8rem; font-weight: 800; }
+.trajectory { height: 190px; display: grid; grid-template-columns: repeat(7, 1fr); align-items: end; gap: 10px; padding: 14px; border-radius: 24px; background: rgba(0,0,0,0.22); }
+.trajectory span { position: relative; min-height: 24px; height: var(--height); border-radius: 999px 999px 10px 10px; background: linear-gradient(to top, var(--blue), var(--mint)); box-shadow: 0 0 28px #8dffd144; }
+.trajectory b { position: absolute; bottom: -24px; left: 50%; transform: translateX(-50%); color: var(--muted); font-size: 0.72rem; }
+.recommendations { margin-top: 38px; }
+.recommendations ul { margin: 0; padding-left: 20px; color: var(--muted); line-height: 1.7; }
+.forecast { margin-top: 26px; }
+.forecast-header { padding: 26px; margin-bottom: 18px; }
+.day-grid { display: grid; grid-template-columns: repeat(7, minmax(235px, 1fr)); gap: 16px; overflow-x: auto; padding-bottom: 10px; }
+.day-card { padding: 20px; transition: transform 180ms ease, border-color 180ms ease; }
+.day-card:hover { transform: translateY(-6px); border-color: #8dffd188; }
+.day-topline { display: flex; justify-content: space-between; gap: 12px; align-items: start; }
+.day-topline span { color: var(--mint); font-size: 0.82rem; font-weight: 900; }
+meter { width: 100%; height: 15px; margin: 10px 0; }
+.theme { color: #dce5ff !important; font-weight: 900; }
+.note { color: var(--mint) !important; }
+@keyframes float { 50% { transform: translate3d(20px, -35px, 0) scale(1.08); } }
+@media (max-width: 900px) { body { overflow: auto; } .workspace { grid-template-columns: 1fr; } .dashboard { position: static; } .metrics { grid-template-columns: repeat(2, 1fr); } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; scroll-behavior: auto !important; } }
+.agent-marquee { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; margin-top: 8px; }
+.agent-marquee span { border: 1px solid #8dffd155; background: rgba(141, 255, 209, 0.09); color: #dcfff3; border-radius: 999px; padding: 10px 14px; font-weight: 900; box-shadow: inset 0 0 18px #8dffd11f; }
+.agent-council { margin-top: 26px; }
+.agent-council > div { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.agent-card { min-height: 160px; padding: 16px; border: 1px solid var(--line); border-radius: 22px; background: linear-gradient(145deg, rgba(141, 255, 209, 0.12), rgba(137, 183, 255, 0.08)); }
+.agent-card strong { display: block; color: var(--text); margin-bottom: 8px; }
+.agent-card span { display: inline-block; color: #08101c; background: var(--mint); border-radius: 999px; padding: 4px 8px; font-size: 0.72rem; font-weight: 1000; text-transform: uppercase; }
+.agent-card p { color: var(--muted); line-height: 1.45; }
+.agent-card small { color: var(--blue); font-weight: 800; }
+@media (max-width: 620px) { .agent-council > div { grid-template-columns: 1fr; } }

--- a/tests/forecaster.test.js
+++ b/tests/forecaster.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const { predictWeek, buildPersona, parseKeywords, runAgents } = require('../forecaster');
+
+const prediction = predictWeek({
+  mood: 7,
+  energy: 6,
+  focus: 8,
+  sleep: 7,
+  stress: 4,
+  social: 6,
+  commitments: 'project due Thursday and gym',
+  goals: 'finish coding practice and sleep earlier',
+  habits: 'exercise journal hydrate',
+});
+
+assert.equal(prediction.days.length, 7);
+assert.match(prediction.summary, /pressure signal/);
+assert.ok(prediction.average >= 1 && prediction.average <= 10);
+assert.ok(prediction.recommendations.length >= 1);
+assert.equal(prediction.agents.length, 4);
+assert.ok(prediction.agents.every((agent) => agent.assignment && agent.specialty));
+assert.ok(prediction.days.every((day) => day.score >= 1 && day.score <= 10));
+assert.ok(prediction.days.every((day) => day.confidence >= 45 && day.confidence <= 88));
+assert.deepEqual(parseKeywords('Sleep earlier, code 2x!'), ['sleep', 'earlier', 'code', '2x']);
+
+const strained = buildPersona({ mood: 3, energy: 3, focus: 4, sleep: 4, stress: 9, social: 2, commitments: 'exam due interview deadline' });
+assert.equal(strained.archetype, 'Careful Recharger');
+assert.equal(runAgents(strained, prediction.days).length, 4);
+
+console.log('Mini Me Forecaster tests passed');

--- a/tests/merge-readiness.test.js
+++ b/tests/merge-readiness.test.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert/strict');
+const { readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const root = join(__dirname, '..');
+const files = ['README.md', 'index.html', 'app.js', 'forecaster.js', 'styles.css', 'tests/forecaster.test.js'];
+
+for (const file of files) {
+  const path = join(root, file);
+  assert.ok(existsSync(path), `${file} should exist after merge`);
+  const content = readFileSync(path, 'utf8');
+  assert.doesNotMatch(content, /<<<<<<<|=======|>>>>>>>/, `${file} should not contain merge conflict markers`);
+}
+
+const html = readFileSync(join(root, 'index.html'), 'utf8');
+for (const asset of ['styles.css', 'forecaster.js', 'app.js']) {
+  assert.match(html, new RegExp(asset.replace('.', '\\.')), `index.html should reference ${asset}`);
+  assert.ok(existsSync(join(root, asset)), `${asset} should be present for the static app`);
+}
+
+assert.match(readFileSync(join(root, 'app.js'), 'utf8'), /MiniMeForecaster\.predictWeek/, 'app.js should wire the UI to the forecaster');
+assert.match(readFileSync(join(root, 'forecaster.js'), 'utf8'), /runAgents/, 'forecaster.js should include the agent council export');
+
+console.log('Merge readiness checks passed');


### PR DESCRIPTION
### Motivation

- Replace the previous holographic demo with a privacy-first, self-contained browser app that turns short personal signals into a seven-day heuristic forecast and action plan.
- Provide a small local forecasting engine and agent council so all inference runs in the client with no server or data exfiltration.

### Description

- Add a forecasting library `forecaster.js` that builds a persona from signals, scores seven days, generates recommendations, and runs a four-agent advisory council, and export it for both CommonJS and the browser as `MiniMeForecaster`.
- Add a lightweight frontend (`index.html`) and wiring in `app.js` that bind a signal journal form to `MiniMeForecaster.predictWeek` and render persona summary, metrics, trajectory, agent cards, recommendations, and a seven-day forecast.
- Add site styling in `styles.css` and update `README.md` to describe highlights, local run instructions, and a test command; remove the previous Three.js hologram code in favor of a streamlined UI.
- Include unit-style smoke tests in `tests/forecaster.test.js` that validate persona building, weekly prediction shape and ranges, keyword parsing, and agent outputs.

### Testing

- Ran the included Node test with `node tests/forecaster.test.js`, which executed assertions covering `predictWeek`, `buildPersona`, `parseKeywords`, and `runAgents` and printed a passing message.
- Test run succeeded with all assertions passing and confirmed days length, score/confidence bounds, agent outputs, and keyword parsing behavior.
- No automated browser tests were added; manual local serve is documented in `README.md` with `python3 -m http.server 4173` and a test command `node tests/forecaster.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d14b88a00832eac1a7d5e29f643a4)